### PR TITLE
Merge dev into main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -931,7 +931,7 @@ jobs:
       # Upload SARIF to GitHub Security
       ######################
       - name: Upload Trivy SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         if: always()
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary

- `ci(security)`: harden binary downloads with version pinning and hash verification
- CI/CD workflow improvements: permissions scoped to job level, Dependabot targeting `dev`, workflow cleanups
- Dockerfile updates and `.env` adjustments
- Test helper refactoring: double brackets, explicit return statements, improved readability
- Dependabot dependency bumps across GitHub Actions (CodeQL, SonarQube, cache, artifacts, etc.)

## Test plan

- [ ] Verify CI/CD workflows pass on merge
- [ ] Confirm Docker build succeeds
- [ ] Check all bats test suites pass (cli, container, proxy, scripts, security)
- [ ] Validate SonarQube scan completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)